### PR TITLE
ES-498: The volume is not mounted successfully according to nexentastor-block-csi-node Log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN chmod 777 /nexentastor-csi-driver-block/chroot-host-wrapper.sh
 RUN    ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/resize2fs \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/findmnt \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/blockdev \
+    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/xfs_growfs \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/blkid \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/e2fsck \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/iscsiadm \
@@ -38,7 +39,8 @@ RUN    ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-c
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/mkfs.xfs \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/multipath \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/multipathd \
-    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/ln
+    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/ln \
+    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/mount
 
 ENV PATH="/nexentastor-csi-driver-block/:${PATH}"
 ENTRYPOINT ["/nexentastor-csi-driver-block/nexentastor-csi-driver-block"]

--- a/Dockerfile.csi-sanity
+++ b/Dockerfile.csi-sanity
@@ -53,7 +53,9 @@ RUN    ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-c
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/mkfs.xfs \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/multipath \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/rm \
-    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/multipathd 
+    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/multipathd \
+    && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/mount
+
 ENV PATH="/nexentastor-csi-driver-block/:${PATH}"
 # copy driver config file
 COPY ./tests/csi-sanity/driver-config-csi-sanity.yaml /config/driver-config-csi-sanity.yaml

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Releases can be found here - https://github.com/Nexenta/nexentastor-csi-driver-b
    | `defaultHostGroup`    | NexentaStor host group to map volumes                           | no         | `all`   |
    | `defaultTarget`       | NexentaStor iSCSI target iqn                                    | yes        | `iqn.2005-07.com.nexenta:01:csiTarget1`|
    | `defaultTargetGroup`  | NexentaStor target group name                                   | yes        | `CSI-tg1`   |
+   | `sparseVolume`         | Defines whether sparse(thin provisioning) should be used. Default `true` | no       | `true`   |
    | `defaultDataIp`       | NexentaStor data IP or HA VIP for mounting shares               | yes for PV | `20.20.20.21`                                                |
    | `dynamicTargetLunAllocation` | If true driver will automatically manage iSCSI target and targetgroup creation (default: false)| no         | `true` |
    | `numOfLunsPerTarget`  | Maximum number of luns that can be assigned to each target with dynamicTargetLunAllocation | no         | `256`                                                       |

--- a/chroot-host-wrapper.sh
+++ b/chroot-host-wrapper.sh
@@ -10,4 +10,4 @@ if [ ! -d "${DIR}" ]; then
 fi
 
 #echo chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" ${ME} "${@:1}"
-exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin" ${ME} "${@:1}"
+exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/bin:/usr/sbin" ${ME} "${@:1}"

--- a/examples/kubernetes/nginx-deployment-dynamic-volume.yaml
+++ b/examples/kubernetes/nginx-deployment-dynamic-volume.yaml
@@ -1,0 +1,118 @@
+# Nginx pod with dynamic storage creation using NexentaStor Block CSI driver
+#
+# $ kubectl apply -f examples/kubernetes/nginx-dynamic-volume.yaml
+#
+# --------------------------------------
+# NexentaStor CSI Driver - Storage Class
+# --------------------------------------
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nexentastor-block-csi-driver-sc-nginx-dynamic
+provisioner: nexentastor-block-csi-driver.nexenta.com
+allowVolumeExpansion: true
+---
+
+# ------------------------------------------------
+# NexentaStor CSI Driver - Persistent Volume Claim
+# ------------------------------------------------
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nexentastor-block-csi-driver-pvc-nginx-dynamic
+spec:
+  storageClassName: nexentastor-block-csi-driver-sc-nginx-dynamic
+  accessModes:
+    # - ReadWriteMany
+    - ReadWriteOnce
+  # volumeMode: Block
+  resources:
+    requests:
+      storage: 1Gi
+---
+
+# ------------------------------------------------
+# NexentaStor CSI Driver - Persistent Volume Claim
+# ------------------------------------------------
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nexentastor-block-csi-driver-pvc-nginx-dynamic-2
+spec:
+  storageClassName: nexentastor-block-csi-driver-sc-nginx-dynamic
+  accessModes:
+    # - ReadWriteMany
+    - ReadWriteOnce
+  # volumeMode: Block
+  resources:
+    requests:
+      storage: 2Gi
+---
+
+# ------------------------------------------------
+# NexentaStor CSI Driver - Persistent Volume Claim
+# ------------------------------------------------
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nexentastor-block-csi-driver-pvc-nginx-dynamic-3
+spec:
+  storageClassName: nexentastor-block-csi-driver-sc-nginx-dynamic
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+---
+
+# ---------
+# Nginx deployment
+# ---------
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-dynamic
+  labels:
+    app.kubernetes.io/name: nginx-deployment-dynamic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-deployment-dynamic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-deployment-dynamic
+    spec:
+      containers:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /mountedDisk
+              name: nexentastor-block-csi-driver-data
+            - mountPath: /mountedDisk-2
+              name: nexentastor-block-csi-driver-data-2
+            - mountPath: /mountedDisk-3
+              name: nexentastor-block-csi-driver-data-3
+      volumes:
+        - name: nexentastor-block-csi-driver-data
+          persistentVolumeClaim:
+            claimName: nexentastor-block-csi-driver-pvc-nginx-dynamic
+            readOnly: false
+        - name: nexentastor-block-csi-driver-data-2
+          persistentVolumeClaim:
+            claimName: nexentastor-block-csi-driver-pvc-nginx-dynamic-2
+            readOnly: false
+        - name: nexentastor-block-csi-driver-data-3
+          persistentVolumeClaim:
+            claimName: nexentastor-block-csi-driver-pvc-nginx-dynamic-3
+            readOnly: false

--- a/examples/kubernetes/nginx-dynamic-block-volume.yaml
+++ b/examples/kubernetes/nginx-dynamic-block-volume.yaml
@@ -19,11 +19,11 @@ allowVolumeExpansion: true
 #     values:
 #     - zone-1
 parameters:
-  # sparseVolume: "true"               # [optional] Defines whether the volumes should be created sparsed(thin)
+  sparseVolume: "true"               # [optional] Defines whether the volumes should be created sparsed(thin)
 #   csi.storage.k8s.io/fstype: xfs
 #   configName: nstor-box3
-  #dataset: customPool/customDataset # to overwrite "defaultDataset" config property [pool/dataset]
-  #dataIp: 20.20.20.253              # to overwrite "defaultDataIp" config property
+#   dataset: customPool/customDataset # to overwrite "defaultDataset" config property [pool/dataset]
+#   dataIp: 20.20.20.253              # to overwrite "defaultDataIp" config property
 ---
 
 # ------------------------------------------------

--- a/examples/kubernetes/nginx-dynamic-block-volume.yaml
+++ b/examples/kubernetes/nginx-dynamic-block-volume.yaml
@@ -1,6 +1,6 @@
 # Nginx pod with dynamic storage creation using NexentaStor Block CSI driver
 #
-# $ kubectl apply -f examples/kubernetes/nginx-dynamic-volume.yaml
+# $ kubectl apply -f examples/kubernetes/nginx-dynamic-block-volume.yaml
 #
 # --------------------------------------
 # NexentaStor CSI Driver - Storage Class
@@ -20,7 +20,7 @@ allowVolumeExpansion: true
 #     - zone-1
 parameters:
   # sparseVolume: "true"               # [optional] Defines whether the volumes should be created sparsed(thin)
-  # csi.storage.k8s.io/fstype: xfs
+#   csi.storage.k8s.io/fstype: xfs
 #   configName: nstor-box3
   #dataset: customPool/customDataset # to overwrite "defaultDataset" config property [pool/dataset]
   #dataIp: 20.20.20.253              # to overwrite "defaultDataIp" config property
@@ -33,12 +33,13 @@ parameters:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: nexentastor-block-csi-driver-pvc-nginx-dynamic
+  name: nexentastor-block-csi-driver-pvc-nginx-dynamic-block
 spec:
   storageClassName: nexentastor-block-csi-driver-sc-nginx-dynamic
   accessModes:
     - ReadWriteMany
     # - ReadWriteOnce
+  volumeMode: Block
   resources:
     requests:
       storage: 1Gi
@@ -50,20 +51,22 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx-dynamic-volume
+  name: nginx-dynamic-block-volume
 spec:
   containers:
     - image: nginx
+      securityContext:
+        privileged: true
       imagePullPolicy: IfNotPresent
       name: nginx
       ports:
         - containerPort: 80
           protocol: TCP
-      volumeMounts:
-        - mountPath: /mountedDisk
-          name: nexentastor-block-csi-driver-data
+      volumeDevices:
+        - devicePath: /dev/sdf
+          name: nexentastor-block-csi-driver-data-block
   volumes:
-    - name: nexentastor-block-csi-driver-data
+    - name: nexentastor-block-csi-driver-data-block
       persistentVolumeClaim:
-        claimName: nexentastor-block-csi-driver-pvc-nginx-dynamic
+        claimName: nexentastor-block-csi-driver-pvc-nginx-dynamic-block
         readOnly: false

--- a/examples/kubernetes/nginx-dynamic-volume.yaml
+++ b/examples/kubernetes/nginx-dynamic-volume.yaml
@@ -18,7 +18,9 @@ allowVolumeExpansion: true
 #   - key: topology.kubernetes.io/zone
 #     values:
 #     - zone-1
-# parameters:
+parameters:
+  # sparseVolume: "true"               # [optional] Defines whether the volumes should be created sparsed(thin)
+#   csi.storage.k8s.io/fstype: xfs
 #   configName: nstor-box3
   #dataset: customPool/customDataset # to overwrite "defaultDataset" config property [pool/dataset]
   #dataIp: 20.20.20.253              # to overwrite "defaultDataIp" config property
@@ -37,10 +39,10 @@ spec:
   accessModes:
     - ReadWriteMany
     # - ReadWriteOnce
-  volumeMode: Block
+  # volumeMode: Block
   resources:
     requests:
-      storage: 2Gi
+      storage: 1Gi
 ---
 # ---------
 # Nginx pod
@@ -58,10 +60,10 @@ spec:
       ports:
         - containerPort: 80
           protocol: TCP
-      # volumeMounts:
-      #   - mountPath: /mountedDisk
-      volumeDevices:
-        - devicePath: /dev/sdc
+      volumeMounts:
+        - mountPath: /mountedDisk
+      # volumeDevices:
+      #   - devicePath: /dev/sdc
           name: nexentastor-block-csi-driver-data
   volumes:
     - name: nexentastor-block-csi-driver-data

--- a/examples/kubernetes/nginx-unprivileged.yaml
+++ b/examples/kubernetes/nginx-unprivileged.yaml
@@ -1,0 +1,69 @@
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nexentastor-block-csi-driver-sc-nginx-dynamic
+provisioner: nexentastor-block-csi-driver.nexenta.com
+allowVolumeExpansion: true
+# volumeBindingMode: Immediate
+# allowedTopologies:
+# - matchLabelExpressions:
+#   - key: topology.kubernetes.io/zone
+#     values:
+#     - zone-1
+# parameters:
+#   configName: nstor-box3
+  #dataset: customPool/customDataset # to overwrite "defaultDataset" config property [pool/dataset]
+  #dataIp: 20.20.20.253              # to overwrite "defaultDataIp" config property
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nexentastor-block-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nexentastor-block-csi-driver-sc-nginx-dynamic
+  resources:
+    requests:
+      storage: 4Gi
+---
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-unprivileged-nexentastor-block
+  labels:
+    app.kubernetes.io/name: nexentastor-block
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nexentastor-block
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nexentastor-block
+    spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
+      automountServiceAccountToken: false
+      containers:
+      - name: nexentastor-block
+        image: nginxinc/nginx-unprivileged
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/bash", "-c", "--" ]
+        args: [ "while true; do echo $(date) > /var/lib/www/html/timefile; sleep 5; sync; done;" ]
+        volumeMounts:
+         - mountPath: /var/lib/www/html
+           name: pvc
+      volumes:
+      - name: pvc
+        persistentVolumeClaim:
+          claimName: nexentastor-block-claim
+
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Nexenta/nexentastor-csi-driver-block
 go 1.13
 
 require (
-	github.com/Nexenta/go-nexentastor v2.6.0+incompatible
+	github.com/Nexenta/go-nexentastor v2.6.1+incompatible
 	github.com/antonfisher/nested-logrus-formatter v1.1.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/container-storage-interface/spec v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/Nexenta/go-nexentastor v2.5.67+incompatible h1:IL8ZpzohatZvINi07IzJub
 github.com/Nexenta/go-nexentastor v2.5.67+incompatible/go.mod h1:AeOU2WLKqHJqeeTfz2xCxx0jGuNKbhbrb6/SLOy53vo=
 github.com/Nexenta/go-nexentastor v2.6.0+incompatible h1:EKP045gSywoXv8IE/zVnLQ3reYGrjm+09Mo1n/9MuQ8=
 github.com/Nexenta/go-nexentastor v2.6.0+incompatible/go.mod h1:AeOU2WLKqHJqeeTfz2xCxx0jGuNKbhbrb6/SLOy53vo=
+github.com/Nexenta/go-nexentastor v2.6.1+incompatible h1:YRQNtj1zGHXTTUYEp/as0Ia2KDnG13HtmMOYYxYWHDY=
+github.com/Nexenta/go-nexentastor v2.6.1+incompatible/go.mod h1:AeOU2WLKqHJqeeTfz2xCxx0jGuNKbhbrb6/SLOy53vo=
 github.com/OpenPeeDeeP/depguard v1.0.0/go.mod h1:7/4sitnI9YlQgTLLk734QlzXT8DuHVnAyztLplQjk+o=
 github.com/OpenPeeDeeP/depguard v1.0.1 h1:VlW4R6jmBIv3/u1JNlawEvJMM4J+dPORPaZasQee8Us=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=

--- a/pkg/driver/controllerServer.go
+++ b/pkg/driver/controllerServer.go
@@ -340,7 +340,7 @@ func (s *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
             VolumeSize: capacityBytes,
         })
         if err != nil {
-            return nil, fmt.Errorf("Failed to expand volume volume %s: %s", volumePath, err)
+            return nil, fmt.Errorf("Failed to expand volume %s: %s", volumePath, err)
         }
         l.Debugf("expanded volume %+v successfully.", volumePath)
         return &csi.ControllerExpandVolumeResponse{


### PR DESCRIPTION
Fixed issue that sometimes occured for e2fsck with exit code 8. Moved resize2fs to NodeExpandVolume, removed  e2fsck completely.
Ensure removing all luns before deleting the volume
ES-500: sparse volume support	
