### PR TITLE
ES-520: provide a way to control TLS certificate checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build container
-FROM golang:1.16 as builder
+FROM golang:1.17.4 as builder
 WORKDIR /go/src/github.com/Nexenta/nexentastor-csi-driver-block/
 COPY . ./
 ARG VERSION
@@ -42,5 +42,7 @@ RUN    ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-c
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/ln \
     && ln -s /nexentastor-csi-driver-block/chroot-host-wrapper.sh /nexentastor-csi-driver-block/mount
 
+RUN echo $'#!/usr/bin/env sh\nupdate-ca-certificates\n/nexentastor-csi-driver-block/nexentastor-csi-driver-block "$@";\n' > /init.sh
 ENV PATH="/nexentastor-csi-driver-block/:${PATH}"
-ENTRYPOINT ["/nexentastor-csi-driver-block/nexentastor-csi-driver-block"]
+RUN chmod +x /init.sh
+ENTRYPOINT ["/init.sh"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Releases can be found here - https://github.com/Nexenta/nexentastor-csi-driver-b
    | `chapSecret`          | Password/secret for CHAP authentication. Minimun length is 12 symbols   | yes when useChapSecret is `true` | `verysecretpassword`                                                       |
    | `debug`               | print more logs (default: false)                                | no         | `true`                                                       |
    | `zone`                | Zone to match topology.kubernetes.io/zone.                      | no         | `us-west`                                                       |
+   |`insecureSkipVerify`| TLS certificates check will be skipped when `true` (default: 'true')| no | `false` |
 
    **Note**: if parameter `defaultVolumeGroup`/`defaultDataIp` is not specified in driver configuration,
    then parameter `volumeGroup`/`dataIp` must be specified in _StorageClass_ configuration.
@@ -422,6 +423,26 @@ Now that your client is configured, add according values to driver's config or s
     chapUser: admin
     chapSecret: supersecretpassword
 ```
+
+## Checking TLS cecrtificates
+Default driver behavior is to skip certificate checks for all Rest API calls.
+v1.4.4 Release introduces new config parameter `insecureSkipVerify`=<true>.
+When `InsecureSkipVerify` is set to false, the driver will enforce certificate checking.
+To allow adding certificates, nexentastor-csi-driver.yaml has additional volumes added to cnexentastor-block-csi-controller deployment and nexentastor-block-csi-node daemonset.
+```bash
+            - name: certs-dir
+              mountPropagation: HostToContainer
+              mountPath: /usr/local/share/ca-certificates
+        - name: certs-dir
+          hostPath:
+            path: /etc/ssl/  # change this to your tls certificates folder
+            type: Directory
+```
+`/etc/ssl` folder is the default certificates location for Ubuntu. Change this according to your
+OS configuration.
+If you only want to propagate a specific set of certificates instead of the whole cert folder 
+from the host, you can put them in any folder on the host and set in the yaml file accordingly.
+Note that this should be done on every node of the kubernetes cluster.
 
 ## Uninstall
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,6 +81,7 @@ func main() {
 		l.Infof("  - Default dataset: %s", config.DefaultVolumeGroup)
 		l.Infof("  - Default data IP: %s", config.DefaultDataIP)
 		l.Infof("  - Zone: %s", config.Zone)
+		l.Infof(" - InsecureSkipVerify: %+v", *config.InsecureSkipVerify)
 	}
 
 	d, err := driver.NewDriver(driver.Args{

--- a/deploy/kubernetes/nexentastor-csi-driver-block.yaml
+++ b/deploy/kubernetes/nexentastor-csi-driver-block.yaml
@@ -265,12 +265,19 @@ spec:
             - name: secret
               mountPath: /config
               readOnly: true
+            - name: certs-dir
+              mountPropagation: HostToContainer
+              mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: socket-dir
           emptyDir:
         - name: secret
           secret:
             secretName: nexentastor-csi-driver-block-config
+        - name: certs-dir
+          hostPath:
+            path: /etc/ssl/  # change this to your tls certificates folder
+            type: Directory
 ---
 
 
@@ -396,6 +403,9 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
+            - name: certs-dir
+              mountPropagation: HostToContainer
+              mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: socket-dir
           hostPath:
@@ -420,4 +430,8 @@ spec:
         - name: secret
           secret:
             secretName: nexentastor-csi-driver-block-config
+        - name: certs-dir
+          hostPath:
+            path: /etc/ssl/  # change this to your tls certificates folder
+            type: Directory
 ---

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
     "gopkg.in/yaml.v2"
 )
 
+const DefaultInsecureSkipVerify = true
 // NexentaStor address format
 var regexpAddress = regexp.MustCompile("^https?://[^:]+:[0-9]{1,5}$")
 
@@ -42,6 +43,7 @@ type NsData struct {
     ChapUser                    string `yaml:"chapUser"`
     ChapSecret                  string `yaml:"chapSecret"`
     MountPointPermissions       string `yaml:"mountPointPermissions"`
+    InsecureSkipVerify          *bool `yaml:"insecureSkipVerify,omitempty"`
 }
 
 // GetFilePath - get filepath of found config file
@@ -112,6 +114,12 @@ func (c *Config) Validate() error {
         }
         if data.Password == "" {
             errors = append(errors, fmt.Sprintf("parameter 'password' is missed"))
+        }
+
+        if data.InsecureSkipVerify == nil {
+            insecureSkipVerify := DefaultInsecureSkipVerify
+            data.InsecureSkipVerify = &insecureSkipVerify
+            c.NsMap[name] = data
         }
 
         if len(errors) != 0 {


### PR DESCRIPTION
insecureSkipVerify config param to control whether we want to check or ignore TLS certificates