### PR TITLE
ES-529 "session expired" error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Nexenta/nexentastor-csi-driver-block
 go 1.13
 
 require (
-	github.com/Nexenta/go-nexentastor v2.7.0+incompatible
+	github.com/Nexenta/go-nexentastor v2.7.1+incompatible
 	github.com/antonfisher/nested-logrus-formatter v1.1.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/container-storage-interface/spec v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/Nexenta/go-nexentastor v2.6.1+incompatible/go.mod h1:AeOU2WLKqHJqeeTf
 github.com/Nexenta/go-nexentastor v2.6.2+incompatible/go.mod h1:wppz87xWilYDlXno+7VLHXoocrOv76OYnLDj7s1B0C0=
 github.com/Nexenta/go-nexentastor v2.7.0+incompatible h1:piiA/SFl9jTMTnFxXwnWCScCsSPgATi0VgBrVhzjcTY=
 github.com/Nexenta/go-nexentastor v2.7.0+incompatible/go.mod h1:AeOU2WLKqHJqeeTfz2xCxx0jGuNKbhbrb6/SLOy53vo=
+github.com/Nexenta/go-nexentastor v2.7.1+incompatible h1:q+DxyUwdFqKj/cJvM21YS0yfQciV0y+dWtAV6twj4FY=
+github.com/Nexenta/go-nexentastor v2.7.1+incompatible/go.mod h1:AeOU2WLKqHJqeeTfz2xCxx0jGuNKbhbrb6/SLOy53vo=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=


### PR DESCRIPTION
Root Cause : Old session token header was not removed from request object causing the auth/login request to fail with 401 "Expired session. Please login again."
Proposed Fix : Clean Authorization token before sending auth/login request
Testing Done : manual + sanity

related go lib change: https://github.com/Nexenta/go-nexentastor/commit/bca0f2039466bf39a012ca6f40af1518d6f058c0