### PR TITLE
ES-526 bumped alpine version to 3.15.4 to fix CVE-2022-28391

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build &&\
 
 
 # driver container
-FROM alpine:3.10
+FROM alpine:3.15.4
 LABEL name="nexentastor-block-csi-driver"
 LABEL maintainer="Nexenta Systems, Inc."
 LABEL description="NexentaStor Block CSI Driver"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,10 @@ pipeline {
         }
         stage('Push [hub.docker.com]') {
             when {
-                branch 'master'
+                anyOf {
+                    branch 'master'
+                    branch pattern: '\\d\\.\\d\\.\\d', comparator: 'REGEXP'
+                }
             }
             environment {
                 DOCKER = credentials('docker-hub-credentials')
@@ -61,7 +64,10 @@ pipeline {
         }
         stage('Tests [k8s hub.docker.com]') {
             when {
-                branch 'master'
+                anyOf {
+                    branch 'master'
+                    branch pattern: '\\d\\.\\d\\.\\d', comparator: 'REGEXP'
+                }
             }
             steps {
                 sh "TEST_K8S_IP=${params.TEST_K8S_IP} TESTRAIL_URL=${TESTRAIL_URL} TESTRAIL_USR=${TESTRAIL_USR} TESTRAIL_PSWD=${TESTRAIL_PSW} make test-e2e-k8s-remote-image-container"


### PR DESCRIPTION
Root Cause : Trivy scanner shows the following security vulnerabilities
nexentastor-csi-driver-block:master (alpine 3.15.0)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 2)
Proposed Fix : Bump dependant image version to those that have the issues fixed
Testing Done : trivy image nexentastor-csi-driver-block:master