### PR TITLE
ES-535 update to newest versions of sidecar containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build &&\
 
 
 # driver container
-FROM alpine:3.10
+FROM alpine:3.15.4
 LABEL name="nexentastor-block-csi-driver"
 LABEL maintainer="Nexenta Systems, Inc."
 LABEL description="NexentaStor Block CSI Driver"

--- a/deploy/kubernetes/nexentastor-csi-driver-block.yaml
+++ b/deploy/kubernetes/nexentastor-csi-driver-block.yaml
@@ -62,7 +62,7 @@ rules:
     verbs: ['list', 'watch', 'create', 'update', 'patch']
   # attacher specific
   - apiGroups: ['']
-    resources: ['nodes']
+    resources: ['nodes', 'pods']
     verbs: ['get', 'list', 'watch']
   - apiGroups: ['csi.storage.k8s.io']
     resources: ['csinodeinfos']
@@ -76,7 +76,7 @@ rules:
     verbs: ['get', 'list', 'watch']
   - apiGroups: ['snapshot.storage.k8s.io']
     resources: ['volumesnapshotcontents']
-    verbs: ['create', 'get', 'list', 'watch', 'update', 'delete']
+    verbs: ['create', 'get', 'list', 'watch', 'update', 'delete', 'patch']
   - apiGroups: ['snapshot.storage.k8s.io']
     resources: ['volumesnapshots']
     verbs: ['get', 'list', 'watch', 'update']
@@ -216,7 +216,7 @@ spec:
         # csi-provisioner: sidecar container that watches Kubernetes PersistentVolumeClaim objects
         # and triggers CreateVolume/DeleteVolume against a CSI endpoint
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -228,7 +228,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
           imagePullPolicy: IfNotPresent
           args:
             - -v=3
@@ -237,7 +237,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -356,7 +356,7 @@ spec:
         # 1) registers the CSI driver with kubelet
         # 2) adds the drivers custom NodeId to a label on the Kubernetes Node API Object
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=3


### PR DESCRIPTION
Root cause: outdated sidecar containers had security vulnerabilities
Proposed fix: update sidecar containers to latest available releases
Testing done: manual + sanity tests