### PR TITLE
NEX-23686 Increase timeout for iSCSI device scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifeq (${VERSION}, master)
 		--k8sDeploymentFile="/tmp/nexentastor-csi-driver-block-local.yaml" \
 		--k8sSecretFile="./_configs/driver-config-single-default.yaml"
 else
-	sed -e "s/image: nexenta\/nexentastor-csi-driver-block:master/image: ${REGISTRY_LOCAL}\/nexentastor-csi-driver-block:v${VERSION}/g" \
+	sed -E "s/image: nexenta\/nexentastor-csi-driver-block:v.+/image: ${REGISTRY_LOCAL}\/nexentastor-csi-driver-block:v${VERSION}/g" \
 		./deploy/kubernetes/nexentastor-csi-driver-block.yaml > /tmp/nexentastor-csi-driver-block-local.yaml
 	go test -timeout 20m tests/e2e/driver_test.go -v -count 1 \
 		--k8sConnectionString="root@${TEST_K8S_IP}" \

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Releases can be found here - https://github.com/Nexenta/nexentastor-csi-driver-b
    | `debug`               | print more logs (default: false)                                | no         | `true`                                                       |
    | `zone`                | Zone to match topology.kubernetes.io/zone.                      | no         | `us-west`                                                       |
    |`insecureSkipVerify`| TLS certificates check will be skipped when `true` (default: 'true')| no | `false` |
+   |`iSCSITimeout`| Maximum time for iSCSI device discovery (default: '300')| no | `200` |
 
    **Note**: if parameter `defaultVolumeGroup`/`defaultDataIp` is not specified in driver configuration,
    then parameter `volumeGroup`/`dataIp` must be specified in _StorageClass_ configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type NsData struct {
     DefaultISCSIPort            string `yaml:"defaultiSCSIPort,omitempty"`
     DefaultDataIP               string `yaml:"defaultDataIp,omitempty"`
     ISCSITargetPrefix           string `yaml:"iSCSITargetPrefix,omitempty"`
+    ISCSITimeout                string `yaml:"iSCSITimeout,omitempty"`
     DynamicTargetLunAllocation  *bool   `yaml:"dynamicTargetLunAllocation"`
     NumOfLunsPerTarget          string `yaml:"numOfLunsPerTarget"`
     UseChapAuth                 string `yaml:"useChapAuth"`

--- a/pkg/driver/nodeServer.go
+++ b/pkg/driver/nodeServer.go
@@ -1130,7 +1130,11 @@ func (s *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCa
     *csi.NodeGetCapabilitiesResponse,
     error,
 ) {
-    s.log.WithField("func", "NodeGetCapabilities()").Infof("request: '%+v'", req)
+    if len(req.String()) != 0 {
+        s.log.WithField("func", "NodeGetCapabilities()").Infof("request: '%+v'", req)
+    } else {
+        s.log.WithField("func", "NodeGetCapabilities()").Debugf("request: '%+v'", req)
+    }
 
     return &csi.NodeGetCapabilitiesResponse{
         Capabilities: []*csi.NodeServiceCapability{


### PR DESCRIPTION
Root cause: lunmapping requests returns by nef, but is executed async. This results in driver timing out when waiting for the iSCSI device.
Proposed fix: Increase default timeout and make it configurable.
Testing done: manual testing.